### PR TITLE
Fix missing init call, renamed ds map functions to avoid name collision, fix issue in AppleSignIn_AuthoriseUser

### DIFF
--- a/source/AppleSignIn_gml/extensions/AppleSignIn/AppleSignIn.yy
+++ b/source/AppleSignIn_gml/extensions/AppleSignIn/AppleSignIn.yy
@@ -33,7 +33,7 @@
         {"$GMExtensionFunction":"","%Name":"AppleSignIn_AddScope","argCount":0,"args":[1,],"documentation":"","externalName":"AppleSignIn_AddScope","help":"AppleSignIn_AddScope(scope)","hidden":false,"kind":4,"name":"AppleSignIn_AddScope","resourceType":"GMExtensionFunction","resourceVersion":"2.0","returnType":2,},
         {"$GMExtensionFunction":"","%Name":"AppleSignIn_ClearScopes","argCount":0,"args":[],"documentation":"","externalName":"AppleSignIn_ClearScopes","help":"AppleSignIn_ClearScopes()","hidden":false,"kind":4,"name":"AppleSignIn_ClearScopes","resourceType":"GMExtensionFunction","resourceVersion":"2.0","returnType":2,},
         {"$GMExtensionFunction":"","%Name":"AppleSignIn_GetCredentialState","argCount":0,"args":[1,],"documentation":"","externalName":"AppleSignIn_GetCredentialState","help":"AppleSignIn_GetCredentialState(identitiy_token)","hidden":false,"kind":4,"name":"AppleSignIn_GetCredentialState","resourceType":"GMExtensionFunction","resourceVersion":"2.0","returnType":2,},
-      ],"init":"","kind":4,"name":"","order":[
+      ],"init":"AppleSignIn_Init","kind":4,"name":"","order":[
         {"name":"AppleSignIn_Init","path":"extensions/AppleSignIn/AppleSignIn.yy",},
         {"name":"AppleSignIn_AuthoriseUser","path":"extensions/AppleSignIn/AppleSignIn.yy",},
         {"name":"AppleSignIn_AddScope","path":"extensions/AppleSignIn/AppleSignIn.yy",},

--- a/source/AppleSignIn_gml/extensions/AppleSignIn/AppleSignIn.yy
+++ b/source/AppleSignIn_gml/extensions/AppleSignIn/AppleSignIn.yy
@@ -11,7 +11,7 @@
   "androidsourcedir":"",
   "author":"",
   "classname":"YY_AppleSignIn",
-  "copyToTargets":3035426170322551022,
+  "copyToTargets":9007199254740998,
   "description":"",
   "exportToGame":true,
   "extensionVersion":"1.2.0",
@@ -27,7 +27,7 @@
         {"$GMExtensionConstant":"","%Name":"applesignin_realuserstatus_likelyreal","hidden":false,"name":"applesignin_realuserstatus_likelyreal","resourceType":"GMExtensionConstant","resourceVersion":"2.0","value":"5002",},
         {"$GMExtensionConstant":"","%Name":"applesignin_realuserstatus_unknown","hidden":false,"name":"applesignin_realuserstatus_unknown","resourceType":"GMExtensionConstant","resourceVersion":"2.0","value":"5001",},
         {"$GMExtensionConstant":"","%Name":"applesignin_realuserstatus_unsupported","hidden":false,"name":"applesignin_realuserstatus_unsupported","resourceType":"GMExtensionConstant","resourceVersion":"2.0","value":"5000",},
-      ],"copyToTargets":3035426153142681838,"filename":"AppleSignIn.ext","final":"","functions":[
+      ],"copyToTargets":9007199254740998,"filename":"AppleSignIn.ext","final":"","functions":[
         {"$GMExtensionFunction":"","%Name":"AppleSignIn_Init","argCount":0,"args":[],"documentation":"","externalName":"AppleSignIn_Init","help":"AppleSignIn_Init()","hidden":true,"kind":4,"name":"AppleSignIn_Init","resourceType":"GMExtensionFunction","resourceVersion":"2.0","returnType":2,},
         {"$GMExtensionFunction":"","%Name":"AppleSignIn_AuthoriseUser","argCount":0,"args":[],"documentation":"","externalName":"AppleSignIn_AuthoriseUser","help":"AppleSignIn_AuthoriseUser()","hidden":false,"kind":4,"name":"AppleSignIn_AuthoriseUser","resourceType":"GMExtensionFunction","resourceVersion":"2.0","returnType":2,},
         {"$GMExtensionFunction":"","%Name":"AppleSignIn_AddScope","argCount":0,"args":[1,],"documentation":"","externalName":"AppleSignIn_AddScope","help":"AppleSignIn_AddScope(scope)","hidden":false,"kind":4,"name":"AppleSignIn_AddScope","resourceType":"GMExtensionFunction","resourceVersion":"2.0","returnType":2,},

--- a/source/AppleSignIn_gml/extensions/AppleSignIn/iOSSource/YY_AppleSignIn.h
+++ b/source/AppleSignIn_gml/extensions/AppleSignIn/iOSSource/YY_AppleSignIn.h
@@ -21,7 +21,7 @@
 
 @end
 
-extern int CreateDsMap_comaptibility_();
-extern void DsMapAddString_comaptibility_(int dsMapIndex, const char* _key, const char* _value);
-extern void DsMapAddDouble_comaptibility_(int dsMapIndex, const char* _key, double _value);
-extern void CreateAsyncEventWithDSMap_comaptibility_(int dsMapIndex);
+extern int CreateDsMap_comaptibility_apple_sign_in();
+extern void DsMapAddString_comaptibility_apple_sign_in(int dsMapIndex, const char* _key, const char* _value);
+extern void DsMapAddDouble_comaptibility_apple_sign_in(int dsMapIndex, const char* _key, double _value);
+extern void CreateAsyncEventWithDSMap_comaptibility_apple_sign_in(int dsMapIndex);

--- a/source/AppleSignIn_gml/extensions/AppleSignIn/iOSSource/YY_AppleSignIn.mm
+++ b/source/AppleSignIn_gml/extensions/AppleSignIn/iOSSource/YY_AppleSignIn.mm
@@ -213,9 +213,19 @@ void CreateAsyncEventWithDSMap_comaptibility_apple_sign_in(int dsMapIndex)
 	#endif
     {
         ASAuthorizationAppleIDRequest* request = [appleIdProvider createRequest];
+        if (request == nil) {
+            NSLog(@"Error: The authorization request is nil.");
+            return 0.0;
+        }
+
+        ASAuthorizationController* authorizationController = [[ASAuthorizationController alloc] initWithAuthorizationRequests:@[request]];
+        if (authorizationController == nil) {
+            NSLog(@"Error: Authorization controller is nil.");
+            return 0.0;
+        }
+
         request.requestedScopes = requestedScopes;
   
-        ASAuthorizationController* authorizationController = [[ASAuthorizationController alloc] initWithAuthorizationRequests:@[request]];
         authDelegate = [[YY_AppleSignInDelegate alloc] init];
         
         authorizationController.delegate = authDelegate;

--- a/source/AppleSignIn_gml/extensions/AppleSignIn/iOSSource/YY_AppleSignIn.mm
+++ b/source/AppleSignIn_gml/extensions/AppleSignIn/iOSSource/YY_AppleSignIn.mm
@@ -65,7 +65,7 @@ YYEXPORT void YYExtensionInitialise(const struct YYRunnerInterface* _pFunctions,
 	#endif
 }
 
-int CreateDsMap_comaptibility_()
+int CreateDsMap_comaptibility_apple_sign_in()
 {
     #if TARGET_OS_OSX
     return CreateDsMap(0,0);
@@ -74,7 +74,7 @@ int CreateDsMap_comaptibility_()
     #endif
 }
 
-void DsMapAddString_comaptibility_(int dsMapIndex, const char* _key, const char* _value)
+void DsMapAddString_comaptibility_apple_sign_in(int dsMapIndex, const char* _key, const char* _value)
 {
     #if TARGET_OS_OSX
     DsMapAddString(dsMapIndex, _key, _value);
@@ -83,7 +83,7 @@ void DsMapAddString_comaptibility_(int dsMapIndex, const char* _key, const char*
     #endif
 }
 
-void DsMapAddDouble_comaptibility_(int dsMapIndex, const char* _key, double _value)
+void DsMapAddDouble_comaptibility_apple_sign_in(int dsMapIndex, const char* _key, double _value)
 {
     #if TARGET_OS_OSX
     DsMapAddDouble(dsMapIndex, _key, _value);
@@ -92,7 +92,7 @@ void DsMapAddDouble_comaptibility_(int dsMapIndex, const char* _key, double _val
     #endif
 }
 
-void CreateAsyncEventWithDSMap_comaptibility_(int dsMapIndex)
+void CreateAsyncEventWithDSMap_comaptibility_apple_sign_in(int dsMapIndex)
 {
     #if TARGET_OS_OSX
     CreateAsyncEventWithDSMap(dsMapIndex,EVENT_OTHER_SOCIAL);
@@ -188,10 +188,10 @@ void CreateAsyncEventWithDSMap_comaptibility_(int dsMapIndex)
             char jResponse[20];
             sprintf(jResponse, "response_json");
             
-            int dsMapIndex = CreateDsMap_comaptibility_();
-            DsMapAddDouble_comaptibility_(dsMapIndex, jId, applesignin_credential_response);
-            DsMapAddString_comaptibility_(dsMapIndex, jResponse, const_cast<char*>([jsonStr UTF8String]));
-            CreateAsyncEventWithDSMap_comaptibility_(dsMapIndex);
+            int dsMapIndex = CreateDsMap_comaptibility_apple_sign_in();
+            DsMapAddDouble_comaptibility_apple_sign_in(dsMapIndex, jId, applesignin_credential_response);
+            DsMapAddString_comaptibility_apple_sign_in(dsMapIndex, jResponse, const_cast<char*>([jsonStr UTF8String]));
+            CreateAsyncEventWithDSMap_comaptibility_apple_sign_in(dsMapIndex);
             
             [results release];
             [jsonStr release];
@@ -297,10 +297,10 @@ void CreateAsyncEventWithDSMap_comaptibility_(int dsMapIndex)
             char jResponse[20];
             sprintf(jResponse, "response_json");
             
-            int dsMapIndex = CreateDsMap_comaptibility_();
-            DsMapAddDouble_comaptibility_(dsMapIndex, jId, applesignin_credential_response);
-            DsMapAddString_comaptibility_(dsMapIndex, jResponse, const_cast<char*>([jsonStr UTF8String]));
-            CreateAsyncEventWithDSMap_comaptibility_(dsMapIndex);
+            int dsMapIndex = CreateDsMap_comaptibility_apple_sign_in();
+            DsMapAddDouble_comaptibility_apple_sign_in(dsMapIndex, jId, applesignin_credential_response);
+            DsMapAddString_comaptibility_apple_sign_in(dsMapIndex, jResponse, const_cast<char*>([jsonStr UTF8String]));
+            CreateAsyncEventWithDSMap_comaptibility_apple_sign_in(dsMapIndex);
             
             [results release];
             [jsonStr release];

--- a/source/AppleSignIn_gml/extensions/AppleSignIn/iOSSource/YY_AppleSignInDelegate.mm
+++ b/source/AppleSignIn_gml/extensions/AppleSignIn/iOSSource/YY_AppleSignInDelegate.mm
@@ -75,10 +75,10 @@
     char jResponse[20];
     sprintf(jResponse, "response_json");
     
-    int dsMapIndex = CreateDsMap_comaptibility_();
-    DsMapAddDouble_comaptibility_(dsMapIndex, jId, applesignin_signin_response);
-    DsMapAddString_comaptibility_(dsMapIndex, jResponse, const_cast<char*>([jsonStr UTF8String]));
-    CreateAsyncEventWithDSMap_comaptibility_(dsMapIndex);
+    int dsMapIndex = CreateDsMap_comaptibility_apple_sign_in();
+    DsMapAddDouble_comaptibility_apple_sign_in(dsMapIndex, jId, applesignin_signin_response);
+    DsMapAddString_comaptibility_apple_sign_in(dsMapIndex, jResponse, const_cast<char*>([jsonStr UTF8String]));
+    CreateAsyncEventWithDSMap_comaptibility_apple_sign_in(dsMapIndex);
     
     [results release];
     [jsonStr release];
@@ -108,10 +108,10 @@
     char jResponse[20];
     sprintf(jResponse, "response_json");
     
-    int dsMapIndex = CreateDsMap_comaptibility_();
-    DsMapAddDouble_comaptibility_(dsMapIndex, jId, applesignin_signin_response);
-    DsMapAddString_comaptibility_(dsMapIndex, jResponse, const_cast<char*>([jsonStr UTF8String]));
-    CreateAsyncEventWithDSMap_comaptibility_(dsMapIndex);
+    int dsMapIndex = CreateDsMap_comaptibility_apple_sign_in();
+    DsMapAddDouble_comaptibility_apple_sign_in(dsMapIndex, jId, applesignin_signin_response);
+    DsMapAddString_comaptibility_apple_sign_in(dsMapIndex, jResponse, const_cast<char*>([jsonStr UTF8String]));
+    CreateAsyncEventWithDSMap_comaptibility_apple_sign_in(dsMapIndex);
     
     [results release];
     [jsonStr release];


### PR DESCRIPTION
1. I added the missing init
2. Renamed all the ds map functions as I ran into name collision issues with other extension from yoyo. I assume others will have the same issue in the future.
3. If the call `[appleIdProvider createRequest]` fails, because of a misconfigurations for example, the request will be nil and it took me a while to figure out what the issue was because there wasn't a useful error being shown so I added some nil checking.