### PR TITLE
Replaced cross-platform function names and removed constants from the documentation, added AppleSignIn_LoginOAuth

### DIFF
--- a/docs/documentation.js
+++ b/docs/documentation.js
@@ -206,7 +206,7 @@ function AppleSignIn_GetCredentialState() {}
  * @event social
  * @desc 
  * @member {string} type The string `"apple_signin_login_oauth"`
- * @member {string} nonce The nonce returned
+ * @member {string} nonce The nonce sent with the request
  * @member {string} client_id The client ID
  * @member {string} redirect_uri The redirect URI
  * @event_end
@@ -218,9 +218,9 @@ function AppleSignIn_GetCredentialState() {}
  * The above code starts the login process for logging in using Apple credentials. Since the optional `scopes` parameter isn't provided, the default scopes are requested.
  * The function call will bring up a browser window in which the user can grant your game access to the requested scopes on the user's behalf.
  * 
- * After the function call a ${event.social} is triggered: 
+ * The function finally triggers a ${event.social}: 
  * ```gml
- * /// Social Async Event
+ * /// Async - Social Event
  * if (async_load[? "type"] == "apple_signin_login_oauth") {
  *     nonce = async_load[? "nonce"];
  *     client_id = async_load[? "client_id"];
@@ -232,12 +232,12 @@ function AppleSignIn_GetCredentialState() {}
  * ```
  * 
  * If the user confirms, an authorization code is sent to the URL that you've set under **OAuth Redirect URL** in the [Extension Options](manual.gamemaker.io/monthly/en/The_Asset_Editors/Extensions.htm#extension_options).
- * The Redirect URL is a URL on your own server to which the authorisation code is sent. Your server code needs to handle receiving the code and then send a POST request to the following endpoint to exchange the code for the access token: `https://appleid.apple.com/auth/token`.
+ * The Redirect URL is a URL on your own server to which the authorisation code is sent. Your server code needs to handle receiving the code and then send a POST request to the following endpoint to exchange the code for the access token: `https://appleid.apple.com/auth/token`. See the demo project for more information on what to include in the request to this endpoint.
  * 
  * If all went well, at one point your server will have received the access token. It is then up to your game to periodically (e.g., using an ${event.alarm}) send a POST request to the same server (to the search URL) to check if it has the token. The code to do this might look as follows:
  * 
  * ```gml
- * /// Alarm 0
+ * /// Alarm 0 Event
  * var _headers = ds_map_create();
  * ds_map_add(_headers, "Content-Type", "application/json");
  * 

--- a/docs/documentation.js
+++ b/docs/documentation.js
@@ -267,7 +267,7 @@ function AppleSignIn_GetCredentialState() {}
  * 
  * > [Apple Developer: Sign In With Apple](https://developer.apple.com/sign-in-with-apple/get-started/)
  * 
- * The Sign In functionality is available on macOS, iOS and tvOS using the SDK and on all other platforms using OAuth.
+ * [[Note: The Sign In functionality is available on macOS, iOS and tvOS using the SDK as well as on all other platforms using OAuth.]]
  * 
  * @section Guides
  * @description The following guides are available for this extension: 

--- a/docs/documentation.js
+++ b/docs/documentation.js
@@ -34,98 +34,62 @@
  * @const_end
  */
 
-/** 
- * @const mac_applesignin_scope
- * @desc These constants specify the scope.
- * @member mac_applesignin_scope_fullname Requests the user's full name.
- * @member mac_applesignin_scope_email Requests the user's e-mail address.
- * @const_end
- */
-
-/** 
- * @const mac_applesignin_response
- * @desc These constants specify the type of response.
- * @member mac_applesignin_signin_response Requests the user's full name.
- * @member mac_applesignin_credential_response Requests the user's e-mail address.
- * @const_end
- */
-
-/** 
- * @const mac_applesignin_realuserstatus
- * @desc These constants specify a user status.
- * @member mac_applesignin_realuserstatus_likelyreal The user is likely a real person.
- * @member mac_applesignin_realuserstatus_unknown The system hasn't determined whether the user might be a real person.
- * @member mac_applesignin_realuserstatus_unsupported This indicates that the IAP product ID has already been added to the internal product list.
- * @const_end
- */
-
-/** 
- * @const mac_applesignin_state
- * @desc These constants specify the user's authorisation state.
- * @member mac_applesignin_state_authorized The user has been authorised and has a valid session.
- * @member mac_applesignin_state_revoked The user's credentials have been revoked and the session terminated.
- * @member mac_applesignin_state_not_found The user doesn't appear to have a session with your app.
- * @const_end
- */
-
 // FUNCTIONS
 
 /**
- * @func AppleSignIn_CrossPlatform_AddScope
+ * @func AppleSignIn_AddScope
  * @desc This function adds a scope for the sign in request to request additional pieces of user data.
  * 
- * The additional data you can request are for an email address and the user's full name. These are requested using the ${constant.applesignin_scope} or ${constant.mac_applesignin_scope} constants.
+ * The additional data you can request are for an email address and the user's full name. These are requested using the ${constant.applesignin_scope} constants.
  * 
- * @param {constant.applesignin_scope|constant.mac_applesignin_scope} scope One of the scope constants
+ * @param {constant.applesignin_scope} scope One of the scope constants
  * 
  * @example
  * The following code example would go in the ${event.step} of a button object to check for a user wanting to sign in using the Apple Sign In API:
  * 
  * ```gml
- * if mouse_check_button_pressed(mb_left)
+ * if (mouse_check_button_pressed(mb_left))
  * {
- *     if instance_position(mouse_x, mouse_y, id)
+ *     if (instance_position(mouse_x, mouse_y, id))
  *     {
- *         AppleSignIn_CrossPlatform_AddScope(applesignin_scope_fullname);
- *         AppleSignIn_CrossPlatform_AddScope(applesignin_scope_email);
- *         AppleSignIn_CrossPlatform_AuthoriseUser();
+ *         AppleSignIn_AddScope(applesignin_scope_fullname);
+ *         AppleSignIn_AddScope(applesignin_scope_email);
+ *         AppleSignIn_AuthoriseUser();
  *     }
  * }
  * ```
  * @func_end
  */
-function AppleSignIn_CrossPlatform_AddScope() {}
+function AppleSignIn_AddScope() {}
 
 /**
- * @func AppleSignIn_CrossPlatform_ClearScopes
+ * @func AppleSignIn_ClearScopes
  * @desc This function clears the scope(s) set for the user when requesting Sign In authorisation.
  * 
  * In general this is not required at any time, but may be useful if you wish to – for example – have a sign in with email and full name permissions.
  * The user may cancel this as they don't want to share that data, so you can clear the permissions using this function and then let them sign in again with only basic permission scopes.
  * 
- * @example The code below shows an example of the ${event.social} after the user has pressed a button to sign in to your app and the function ${function.AppleSignIn_CrossPlatform_AuthoriseUser} has been called:
+ * @example The code below shows an example of the ${event.social} after the user has pressed a button to sign in to your app and the function ${function.AppleSignIn_AuthoriseUser} has been called:
  * 
  * ```gml
  * var _event_id = async_load[? "id"];
  * switch (_event_id)
  * {
  *     case applesignin_signin_response:
- *     case mac_applesignin_signin_response:
  *         global.appleSignInState = -1;
  *         var _json = async_load[? "response_json"];
- *         if _json != ""
+ *         if (_json != "")
  *         {
- *             var _map = json_decode(_json);
- *             if _map[? "success"] == true
+ *             var _response = json_parse(_json);
+ *             if (_response.success)
  *             {
  *                 show_debug_message("Apple Sign In Succeeded");
  *                 global.appleSignInState = applesignin_state_authorized;
  *             }
- *             ds_map_destroy(_map);
  *         }
- *         if global.appleSignInState == -1
+ *         if (global.appleSignInState == -1)
  *         {
- *             AppleSignIn_CrossPlatform_ClearScopes();
+ *             AppleSignIn_ClearScopes();
  *         }
  *         break;
  * }
@@ -133,30 +97,30 @@ function AppleSignIn_CrossPlatform_AddScope() {}
  * 
  * @func_end
  */
-function AppleSignIn_CrossPlatform_ClearScopes() {}
+function AppleSignIn_ClearScopes() {}
 
 /**
- * @func AppleSignIn_CrossPlatform_AuthoriseUser
+ * @func AppleSignIn_AuthoriseUser
  * @desc This function authorises a user using the Apple Sign In API and their Apple ID credentials.
  * 
- * The ${var.async_load} map will contain the key "response_json", which can then be decoded into another DS map using the function ${function.json_decode} or into a struct using ${function.json_parse}.
+ * The ${var.async_load} map will contain the key `"response_json"`, which can be parsed into a struct using ${function.json_parse}.
  * 
  * @event social
  * @desc The following keys are always present: 
  * @member {boolean} success This contains whether authorisation was granted or not. If this is `false`, none of the other keys listed will be present.
  * @member {string} identityToken This holds the unique identity token string for the session.
  * @member {string} userIdentifier This holds the unique user identifier string.
- * @member {constant.applesignin_realuserstatus|constant.mac_applesignin_realuserstatus} realUserStatus This holds the real user status of the user.
+ * @member {constant.applesignin_realuserstatus} realUserStatus This holds the real user status of the user.
  * @member {string} authCode This holds the unique authorisation code string.
  * @event_end
  * 
  * @event social
- * @desc If you have used the ${function.AppleSignIn_CrossPlatform_AddScope} function before calling the authorise function, then you may have the following additional keys – first, for the `applesignin_scope_email` / `mac_applesignin_scope_email` scope:
+ * @desc If you have used the ${function.AppleSignIn_AddScope} function before calling the authorise function, then you may have the following additional keys – first, for the `applesignin_scope_email` scope:
  * @member {string} email This will be the user's email address
  * @event_end
  * 
  * @event social
- * @desc For the `applesignin_scope_fullname` / `mac_applesignin_scope_fullname` scope (note that all of these contain an empty string `""` if not available):
+ * @desc For the `applesignin_scope_fullname` scope (note that all of these contain an empty string `""` if not available):
  * @member {string} namePrefix The user's name prefix
  * @member {string} phoneticRepresentation A phonetic representation of the name
  * @member {string} givenName The first name of the user
@@ -174,41 +138,39 @@ function AppleSignIn_CrossPlatform_ClearScopes() {}
  * switch (_event_id)
  * {
  *     case applesignin_signin_response:
- *     case mac_applesignin_signin_response:
  *         global.appleSignInState = -1;
  *         var _json = async_load[? "response_json"];
- *         if _json != ""
+ *         if (_json != "")
  *         {
- *             var _map = json_decode(_json);
- *             if _map[? "success"] == true
+ *             var _response = json_parse(_json);
+ *             if (_response.success)
  *             {
  *                 show_debug_message("Apple Sign In Succeeded");
  *                 global.appleSignInState = applesignin_state_authorized;
  *             }
- *             ds_map_destroy(_map);
  *         }
  *         break;
  * }
  * ```
  * 
- * A global variable stores the sign in state for future reference, where -1 means not signed in / no action has been taken. You can use one of the ${constant.applesignin_state} or ${constant.mac_applesignin_state} extension constants to check for other states as required.
+ * A global variable stores the sign in state for future reference, where -1 means not signed in / no action has been taken. You can use one of the ${constant.applesignin_state} extension constants to check for other states as required.
  * 
  * @func_end
  */
-function AppleSignIn_CrossPlatform_AuthoriseUser() {}
+function AppleSignIn_AuthoriseUser() {}
 
 /**
- * @func AppleSignIn_CrossPlatform_GetCredentialState
+ * @func AppleSignIn_GetCredentialState
  * @desc This function retrieves the credential sign in state for your game.
  * 
- * You supply the identity token string for the session (returned as part of the callback when you use the function ${function.AppleSignIn_CrossPlatform_AuthoriseUser} and the function will trigger an ${event.social} where the {var.async_load} DS map **"id"** key will be `applesignin_credential_response` or `mac_applesignin_credential_response`.
+ * You supply the identity token string for the session (returned as part of the callback when you use the function ${function.AppleSignIn_AuthoriseUser} and the function will trigger an ${event.social} where the {var.async_load} DS map `"id"` key will be `applesignin_credential_response`.
  * 
- * The ${var.async_load} map will then have a further key "response_json", which will hold a JSON string which can be parsed into a DS map using the function ${function.json_decode}. This map will have the key **"status"**, which will be one of the ${constant.applesignin_state} or ${constant.mac_applesignin_state} constants.
+ * The ${var.async_load} map will then have a further key `"response_json"`, which will hold a JSON string which can be parsed into a struct using the function ${function.json_parse}. This map will have the key `"status"`, which will be one of the ${constant.applesignin_state} constants.
  * @param {string} token The session identity token
  * 
  * @event social
  * @desc The event of `applesignin_credential_response`. It contains the following: 
- * @member {constant.applesignin_state|constant.mac_applesignin_state} status The authorisation status of the user
+ * @member {constant.applesignin_state} status The authorisation status of the user
  * @event_end
  * 
  * @example
@@ -219,14 +181,12 @@ function AppleSignIn_CrossPlatform_AuthoriseUser() {}
  * switch (_event_id)
  * {
  *     case applesignin_credential_response:
- *     case mac_applesignin_credential_response:
  *         global.appleSignInState = -1;
  *         var _json = async_load[? "response_json"];
- *         if _json != ""
+ *         if (_json != "")
  *         {
- *             var _map = json_decode(_json);
- *             global.appleSignInState = _map[? "state"];
- *             ds_map_destroy(_map);
+ *             var _response = json_parse(_json);
+ *             global.appleSignInState = _response.state;
  *         }
  *         break;
  * }
@@ -234,25 +194,44 @@ function AppleSignIn_CrossPlatform_AuthoriseUser() {}
  * 
  * @func_end
  */
-function AppleSignIn_CrossPlatform_GetCredentialState() {}
+function AppleSignIn_GetCredentialState() {}
 
 /**
- * @func Mac_AppleSignIn_RegisterWindow
- * @desc This **macOS only** function must be used before calling any other function to register the game window for authorisation UI overlays.
+ * @func AppleSignIn_LoginOAuth
+ * @desc This function triggers the OAuth process for logging in with an Apple account.
  * 
- * [[NOTE: You don't need to call this yourself if you use the `_CrossPlatform` versions of the functions. The function ${function.AppleSignIn_CrossPlatform_AuthoriseUser} calls this function on iOS and tvOS.]]
+ * @param {string} state A unique state string used for security and validation during the OAuth process.
+ * @param {String} scopes The scopes that will be requested when performing the OAuth authorization. Defaults to `"name email"`.
+ * 
+ * @event social
+ * @desc 
+ * @member {string} type The string `"apple_signin_login_oauth"`
+ * @member {string} nonce The nonce returned
+ * @member {string} client_id The client ID
+ * @member {string} redirect_uri The redirect URI
+ * @event_end
  * 
  * @example
- * The following code example would go in the ${event.step} of a button object to check for a user wanting to sign in using the Apple Sign In API:
- * 
  * ```gml
- * Mac_AppleSignIn_RegisterWindow();
- * Mac_AppleSignIn_AuthoriseUser();
+ * AppleSignIn_LoginOAuth(state);
+ * ```
+ * The above code starts the login process for logging in.
+ * 
+ * This then triggers a ${event.social}: 
+ * ```gml
+ * /// Social Async Event
+ * if (async_load[? "type"] == "apple_signin_login_oauth") {
+ *     nonce = async_load[? "nonce"];
+ *     client_id = async_load[? "client_id"];
+ *     redirect_uri = async_load[? "redirect_uri"];
+ *     
+ *     // Query the token from the server
+ *     // ...
+ * }
  * ```
  * 
  * @func_end
  */
-function Mac_AppleSignIn_RegisterWindow() {}
 
 // MODULES
 
@@ -267,11 +246,6 @@ function Mac_AppleSignIn_RegisterWindow() {}
  * We recommend that before doing anything with this extension, you take a moment to look over the official Apple Sign In API documentation, as it will familiarise you with many of the terms and concepts required to use the extension correctly:
  * 
  * * [Apple Developer: Sign In With Apple](https://developer.apple.com/sign-in-with-apple/get-started/)
- * 
- * [[NOTE: The macOS and iOS/tvOS Sign In functions **work exactly the same way and have only been separated into two extensions so that you can use one or the other or both as required**.
- * This means that you may need to do certain checks using the [`os_type`](https://manual-en.yoyogames.com/GameMaker_Language/GML_Reference/OS_And_Compiler/os_type.htm) variable to call the correct function for the current platform the game is running on, but the bulk of the code will be the same regardless.
- * * This wiki provides a reference of the additional **functions** in the `AppleSignInCrossPlatformFunctions` script asset, included with the demo project. These functions are named `AppleSignIn_CrossPlatform_*` and call the correct underlying function, independent of the current [`os_type`](https://manual-en.yoyogames.com/GameMaker_Language/GML_Reference/OS_And_Compiler/os_type.htm).
- * * The tvOS/iOS **constants** and their macOS counterparts, however, currently do not share the same value internally and so you should make sure to always check against **both** constants when using the `AppleSignIn_CrossPlatform_*` functions in your code.]]
  * 
  * @section Guides
  * @description The following guides are available for this extension: 
@@ -293,16 +267,13 @@ function Mac_AppleSignIn_RegisterWindow() {}
  * Some of the examples are Extended Examples that also show code from callbacks in the ${event.social}.
  *
  * @section_func
- * @ref function.AppleSignIn_CrossPlatform_AddScope
- * @ref function.AppleSignIn_CrossPlatform_ClearScopes
- * @ref function.AppleSignIn_CrossPlatform_AuthoriseUser
- * @ref function.AppleSignIn_CrossPlatform_GetCredentialState
- * @ref function.Mac_AppleSignIn_RegisterWindow
+ * @desc These are the functions of the Apple Sign In extension:
+ * @ref AppleSignIn_*
  * @section_end
  * 
  * @section_const
+ * @desc These are the constants available in the Apple Sign In extension:
  * @ref applesignin_*
- * @ref mac_applesignin_*
  * @section_end
  * 
  * @module_end

--- a/docs/documentation.js
+++ b/docs/documentation.js
@@ -205,7 +205,7 @@ function AppleSignIn_GetCredentialState() {}
  * 
  * @event social
  * @desc 
- * @member {string} type The string `"apple_signin_login_oauth"`
+ * @member {string} type The string `"AppleSignIn_LoginOAuth"`
  * @member {string} nonce The nonce sent with the request
  * @member {string} client_id The client ID
  * @member {string} redirect_uri The redirect URI

--- a/docs/documentation.js
+++ b/docs/documentation.js
@@ -265,7 +265,9 @@ function AppleSignIn_GetCredentialState() {}
  * This wiki is meant to be used as a reference to the different Apple Sign In extension functions for iOS, tvOS and macOS, and as such does not contain a tutorial on how to set up the API in your games.
  * We recommend that before doing anything with this extension, you take a moment to look over the official Apple Sign In API documentation, as it will familiarise you with many of the terms and concepts required to use the extension correctly:
  * 
- * * [Apple Developer: Sign In With Apple](https://developer.apple.com/sign-in-with-apple/get-started/)
+ * > [Apple Developer: Sign In With Apple](https://developer.apple.com/sign-in-with-apple/get-started/)
+ * 
+ * The Sign In functionality is available on macOS, iOS and tvOS using the SDK and on all other platforms using OAuth.
  * 
  * @section Guides
  * @description The following guides are available for this extension: 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -6,7 +6,7 @@ To test your apps, you'll need to use the latest beta version of Xcode 11 and up
 the latest OS versions (which may require you to update to beta versions).
 
 Additionally, for macOS, to use this extension you will be required to provide a **Signing Identifier** in the 
-[macOS Game Options](https://manual.yoyogames.com/Settings/Game_Options/macOS.htm):
+[macOS Game Options](https://manual.gamemaker.io/monthly/en/Settings/Game_Options/macOS.htm):
 
 ![Signing Identifier](assets/macOS_Game_Options_Signing_Identifier.png "Signing Identifier")
 
@@ -22,7 +22,7 @@ and add it into GameMaker as an [included file](https://manual.yoyogames.com/Set
 
 ![Provisioning Profile in Included Files](assets/Provisioning_Profile_in_Included_Files.png "Provisioning Profile")
 
-This profile should be valid for the **App ID**, **Team Identifier** and **Signing Identifier** used in the [Game Options](https://manual.yoyogames.com/Settings/Game_Options/macOS.htm).
+This profile should be valid for the **App ID**, **Team Identifier** and **Signing Identifier** used in the [Game Options](https://manual.gamemaker.io/monthly/en/Settings/Game_Options/macOS.htm).
 
 Once you have everything set up, it's simply a case of adding a button object into your game and having 
 it call the appropriate functions when pressed, and then parsing the ${event.social} to get the necessary data from the callback.


### PR DESCRIPTION
This PR contains two changes to Apple Sign In documentation:

* Replaced cross-platform function names and removed constants from the documentation
* Added AppleSignIn_LoginOAuth, including a short explanation on how to use in the code example (no server code)